### PR TITLE
fix: replace wrong  lodash import as lodash-es

### DIFF
--- a/src/lib/chartScene.ts
+++ b/src/lib/chartScene.ts
@@ -25,7 +25,7 @@ import sprite from "@/lib/figures/Sprite";
 import { update as tweenUpdate } from "@tweenjs/tween.js";
 import Store from "@/lib/store/store";
 import EventStore from "@/lib/store/eventStore";
-import { merge } from "lodash";
+import { merge } from "lodash-es";
 import CustomOrbitControls from "@/lib/utils/controls";
 import CountryNamesText from "@/lib/figures/Text";
 

--- a/src/lib/figures/FlyLine3d.ts
+++ b/src/lib/figures/FlyLine3d.ts
@@ -19,7 +19,7 @@ import { setTween } from "@/lib/utils/tween";
 import { FlyLineData, LineStyle, StoreConfig } from "@/lib/interface";
 import Store from "@/lib/store/store";
 import { addUserDataToMesh } from "@/lib/utils";
-import { merge } from "lodash";
+import { merge } from "lodash-es";
 import { cloneDeep } from "lodash-es";
 
 export default class FlyLine3d {

--- a/src/lib/figures/Road.ts
+++ b/src/lib/figures/Road.ts
@@ -18,7 +18,7 @@ import {
 } from "three";
 import { _3Dto2D, radianAOB } from "@/lib/utils/math";
 import { setTween } from "@/lib/utils/tween";
-import { merge } from "lodash";
+import { merge } from "lodash-es";
 import { cloneDeep } from "lodash-es";
 
 export class Road {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -12,3 +12,4 @@ function registerMap(name: string, map: FeatureCollection) {
 }
 
 export default { init, registerMap };
+export type { FeatureCollection };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -12,4 +12,3 @@ function registerMap(name: string, map: FeatureCollection) {
 }
 
 export default { init, registerMap };
-export type { FeatureCollection };

--- a/src/lib/store/store.ts
+++ b/src/lib/store/store.ts
@@ -1,5 +1,5 @@
 import { InitConfig, Options, StoreConfig } from "@/lib/interface";
-import { merge } from "lodash";
+import { merge } from "lodash-es";
 
 class Store {
   mode: "2d" | "3d" = "3d";

--- a/src/lib/utils/tween.ts
+++ b/src/lib/utils/tween.ts
@@ -1,5 +1,5 @@
 import * as TWEEN from "@tweenjs/tween.js";
-import { merge } from "lodash";
+import { merge } from "lodash-es";
 export function setTween(
   from: Record<any, any>,
   to: Record<any, any>,


### PR DESCRIPTION
修复错误的`lodash`导入